### PR TITLE
chore(deps): bump go.einride.tech/sage from 0.263.0 to 0.279.1 in /.sage

### DIFF
--- a/.sage/go.mod
+++ b/.sage/go.mod
@@ -2,4 +2,4 @@ module sage
 
 go 1.20
 
-require go.einride.tech/sage v0.263.0
+require go.einride.tech/sage v0.279.1

--- a/.sage/go.sum
+++ b/.sage/go.sum
@@ -1,2 +1,2 @@
-go.einride.tech/sage v0.263.0 h1:osFcb9hOSvYeFp7vGueAADO7Cmmz8zeUhMlie89sP2M=
-go.einride.tech/sage v0.263.0/go.mod h1:EzV5uciFX7/2ho8EKB5K9JghOfXIxlzs694b+Tkl5GQ=
+go.einride.tech/sage v0.279.1 h1:Xq8I4eYG1aqpU8L+kasIX129q0UEyWkH+iyagi7gQgM=
+go.einride.tech/sage v0.279.1/go.mod h1:EzV5uciFX7/2ho8EKB5K9JghOfXIxlzs694b+Tkl5GQ=

--- a/.sage/sagefile.go
+++ b/.sage/sagefile.go
@@ -8,7 +8,6 @@ import (
 	"go.einride.tech/sage/tools/sggit"
 	"go.einride.tech/sage/tools/sggo"
 	"go.einride.tech/sage/tools/sggolangcilint"
-	"go.einride.tech/sage/tools/sggoreview"
 	"go.einride.tech/sage/tools/sgmdformat"
 	"go.einride.tech/sage/tools/sgyamlfmt"
 )
@@ -23,7 +22,7 @@ func main() {
 }
 
 func All(ctx context.Context) error {
-	sg.Deps(ctx, ConvcoCheck, GoBuild, GolangciLint, GoReview, GoTest, FormatMarkdown, FormatYAML)
+	sg.Deps(ctx, ConvcoCheck, GoBuild, GolangciLint, GoTest, FormatMarkdown, FormatYAML)
 	sg.SerialDeps(ctx, GoModTidy, GitVerifyNoDiff)
 	return nil
 }
@@ -54,11 +53,6 @@ func GoModTidy(ctx context.Context) error {
 func GoTest(ctx context.Context) error {
 	sg.Logger(ctx).Println("running Go tests...")
 	return sggo.TestCommand(ctx).Run()
-}
-
-func GoReview(ctx context.Context) error {
-	sg.Logger(ctx).Println("reviewing Go files...")
-	return sggoreview.Command(ctx, "-c", "1", "./...").Run()
 }
 
 func GolangciLint(ctx context.Context) error {

--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,6 @@ go-build: $(sagefile)
 go-mod-tidy: $(sagefile)
 	@$(sagefile) GoModTidy
 
-.PHONY: go-review
-go-review: $(sagefile)
-	@$(sagefile) GoReview
-
 .PHONY: go-test
 go-test: $(sagefile)
 	@$(sagefile) GoTest


### PR DESCRIPTION
Replaces #248

Bumps [go.einride.tech/sage](https://github.com/einride/sage) from 0.263.0 to 0.279.1.
- [Release notes](https://github.com/einride/sage/releases)
- [Commits](https://github.com/einride/sage/compare/v0.263.0...v0.279.1)

---
updated-dependencies:
- dependency-name: go.einride.tech/sage
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>
